### PR TITLE
Fix packaging issue - include HTML templates in pip installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,10 @@ gitphish = "gitphish.__main__:main"
 
 [tool.setuptools.packages.find]
 include = ["gitphish*"]
+
+[tool.setuptools.package-data]
+gitphish = [
+    "core/gui/templates/*.html",
+    "static/landing_page/*.html",
+    "core/deployment/types/github_pages/templates/*.html"
+]


### PR DESCRIPTION
Resolves GitHub issue #1 where TemplateNotFound errors occurred when installing GitPhish via pip install due to missing HTML templates in the package data.

Added package-data configuration to pyproject.toml to properly include:
- GUI templates (dashboard.html, sms_campaigns.html, base.html, etc.)
- Static landing page templates
- GitHub Pages deployment templates

Verified fix by testing wheel installation in clean environment.